### PR TITLE
add opencv_videoio to cffi dependencies

### DIFF
--- a/sb_vision/native/cvcapture_build.py
+++ b/sb_vision/native/cvcapture_build.py
@@ -25,6 +25,7 @@ ffibuilder.set_source(
         str(base / 'cvcapture.cpp'),
     ], libraries=[
         'opencv_core',
+        'opencv_videoio',
         'opencv_highgui',
         'opencv_imgproc',
     ],


### PR DESCRIPTION
add `opencv_videoio` to cffi build dependencies as my machine cannot find symbol `_ZN2cv12VideoCaptureC1Ei` without it.