### PR TITLE
Add a util which was very useful today

### DIFF
--- a/sb_vision/camera.py
+++ b/sb_vision/camera.py
@@ -12,11 +12,13 @@ from sb_vision.cvcapture import CaptureDevice
 
 from .camera_base import CameraBase
 
+from typing import Tuple
+
 
 class Camera(CameraBase):
     """Actual camera, hooked up to a physical device."""
 
-    def __init__(self, device_id, proposed_image_size, distance_model):
+    def __init__(self, device_id: int, proposed_image_size: Tuple[int, int], distance_model: str):
         """Initialise camera with focal length and image size."""
         super().__init__()
         self.cam_image_size = proposed_image_size

--- a/sb_vision/camera.py
+++ b/sb_vision/camera.py
@@ -12,13 +12,11 @@ from sb_vision.cvcapture import CaptureDevice
 
 from .camera_base import CameraBase
 
-from typing import Tuple
-
 
 class Camera(CameraBase):
     """Actual camera, hooked up to a physical device."""
 
-    def __init__(self, device_id: int, proposed_image_size: Tuple[int, int], distance_model: str):
+    def __init__(self, device_id, proposed_image_size, distance_model):
         """Initialise camera with focal length and image size."""
         super().__init__()
         self.cam_image_size = proposed_image_size

--- a/utils/capture_images.py
+++ b/utils/capture_images.py
@@ -35,11 +35,6 @@ class Resolution(collections.namedtuple('Resolution', ('width', 'height'))):
         return '{0.width}x{0.height}'.format(self)
 
 
-def capture_image(device, image_size):
-    image_bytes = device.capture(*image_size)
-    return Image.frombytes('L', image_size, image_bytes)
-
-
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('device_id', type=int)
@@ -63,7 +58,10 @@ def main(args):
     with CaptureDevice(args.device_id) as d:
         for num in range(args.num_images):
             print("Capturing image {}...".format(num), end='')
-            image = capture_image(d, args.resolution)
+
+            image_bytes = d.capture(*args.resolution)
+
+            image = Image.frombytes('L', args.resolution, image_bytes)
 
             with open(args.image_template.format(num), mode='wb') as f:
                 image.save(f)

--- a/utils/capture_images.py
+++ b/utils/capture_images.py
@@ -57,7 +57,7 @@ def parse_args():
 def main(args):
     with CaptureDevice(args.device_id) as capture_device:
         for num in range(args.num_images):
-            print("Capturing image {}...".format(num), end='')
+            print("Capturing image {}...".format(num))
 
             image_bytes = capture_device.capture(*args.resolution)
 

--- a/utils/capture_images.py
+++ b/utils/capture_images.py
@@ -40,10 +40,16 @@ def parse_args():
     parser.add_argument(
         'device_id',
         type=int,
+        help="The id of the video device. For example: for the camera at "
+             "'/dev/video0', this would be 0.",
     )
     parser.add_argument(
         'image_template',
         type=str,
+        help="The file name and path to use for the images, optionally with a "
+             "placeholder for the index of the image within the current "
+             "sequence. For example: '/tmp/foo-{}.png' will result in images "
+             "'/tmp/foo-0.png',' /tmp/foo-1.png' and so on.",
     )
     parser.add_argument(
         '--resolution',

--- a/utils/capture_images.py
+++ b/utils/capture_images.py
@@ -55,11 +55,11 @@ def parse_args():
 
 
 def main(args):
-    with CaptureDevice(args.device_id) as d:
+    with CaptureDevice(args.device_id) as capture_device:
         for num in range(args.num_images):
             print("Capturing image {}...".format(num), end='')
 
-            image_bytes = d.capture(*args.resolution)
+            image_bytes = capture_device.capture(*args.resolution)
 
             image = Image.frombytes('L', args.resolution, image_bytes)
 

--- a/utils/capture_images.py
+++ b/utils/capture_images.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
 
+"""
+Utility to capture images from the camera. Primarily used
+for testing camera compatibility with the platform, though
+potentially also useful for gathering calibration images.
+"""
+
 import argparse
 import collections
 import re
@@ -36,7 +42,7 @@ class Resolution(collections.namedtuple('Resolution', ('width', 'height'))):
 
 
 def parse_args():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         'device_id',
         type=int,

--- a/utils/capture_images.py
+++ b/utils/capture_images.py
@@ -66,6 +66,11 @@ def parse_args():
     parser.add_argument(
         '--num-images',
         type=int,
+        # Note: we default to 2 as we have seen issues with some cameras which
+        # are only able to successfully campture a first image. By expecting
+        # that all cameras will capture two images we avoid accidentally
+        # believing that cameras which fail in this manner are fine when they
+        # are in fact not fine.
         default=2,
         help="The number of images to capture, default: %(default)s",
     )

--- a/utils/capture_images.py
+++ b/utils/capture_images.py
@@ -119,7 +119,11 @@ def parse_args():
 def main(args):
     stopwatch = Stopwatch(on_stop=Stopwatch.print_duration if args.timings else lambda x: None)
 
-    with CaptureDevice(args.device_id) as capture_device:
+    with stopwatch:
+        print("Initialising camera...")
+        capture_device = CaptureDevice(args.device_id)
+
+    with capture_device:
         for num in range(args.num_images):
             print("Capturing image {}...".format(num))
 

--- a/utils/capture_images.py
+++ b/utils/capture_images.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+import argparse
+import collections
+import re
+
+from PIL import Image
+
+from sb_vision.cvcapture import CaptureDevice
+
+
+class Resolution(collections.namedtuple('Resolution', ('width', 'height'))):
+    __slots__ = ()
+
+    @classmethod
+    def from_argument(cls, res):
+        try:
+            return cls.from_string(res)
+        except ValueError as e:
+            raise argparse.ArgumentTypeError(str(e))
+
+    @classmethod
+    def from_string(cls, res):
+        match = re.match(r'(?P<width>\d+)x(?P<height>\d+)', res)
+
+        if match is None:
+            raise ValueError(
+                "Invalid resolution specified. Must be in the form 'WIDTHxHEIGHT'"
+                " (got {})".format(repr(res)),
+            )
+
+        return cls(**{k: int(v) for k, v in match.groupdict().items()})
+
+    def __str__(self):
+        return '{0.width}x{0.height}'.format(self)
+
+
+def capture_image(device, image_size):
+    image_bytes = device.capture(*image_size)
+    return Image.frombytes('L', image_size, image_bytes)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('device_id', type=int)
+    parser.add_argument('image_template', type=str)
+    parser.add_argument(
+        '--resolution',
+        type=Resolution.from_argument,
+        default=Resolution(640, 480),
+        help="The resolution to capture from the device, default: %(default)s",
+    )
+    parser.add_argument(
+        '--num-images',
+        type=int,
+        default=2,
+        help="The number of images to capture, default: %(default)s",
+    )
+    return parser.parse_args()
+
+
+def main(args):
+    with CaptureDevice(args.device_id) as d:
+        for num in range(args.num_images):
+            print("Capturing image {}...".format(num), end='')
+            image = capture_image(d, args.resolution)
+
+            with open(args.image_template.format(num), mode='wb') as f:
+                image.save(f)
+
+            print("done")
+
+
+if __name__ == '__main__':
+    main(parse_args())

--- a/utils/capture_images.py
+++ b/utils/capture_images.py
@@ -63,7 +63,8 @@ def main(args):
 
             image = Image.frombytes('L', args.resolution, image_bytes)
 
-            with open(args.image_template.format(num), mode='wb') as f:
+            file_name = args.image_template.format(num)
+            with open(file_name, mode='wb') as f:
                 image.save(f)
 
             print("done")

--- a/utils/capture_images.py
+++ b/utils/capture_images.py
@@ -37,8 +37,14 @@ class Resolution(collections.namedtuple('Resolution', ('width', 'height'))):
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument('device_id', type=int)
-    parser.add_argument('image_template', type=str)
+    parser.add_argument(
+        'device_id',
+        type=int,
+    )
+    parser.add_argument(
+        'image_template',
+        type=str,
+    )
     parser.add_argument(
         '--resolution',
         type=Resolution.from_argument,


### PR DESCRIPTION
This emerged out of testing a bunch of cameras on a Pi and wanting to be sure that:
- they worked with our image capture behaviour, and
- they could successfully capture multiple images with needing some form of manual reset shenanigans

@prophile I've put this in `utils/` and tidied it up a bit, though I'm not sure if that's the best place for it. I see there's already the start of a CLI for the calibration stuff, though I'm not sure what you had in mind for a CLI of the main library.
I think it would be useful to have a CLI which supports the following, though I think most of it would be beyond the scope of this PR:
- plain image capture,
- image capture with April Tags detection (maybe with a visual overlay), and
- just April Tags detection from a saved image