### PR TITLE
Fix thread guard around closing the camera

### DIFF
--- a/sb_vision/cvcapture.py
+++ b/sb_vision/cvcapture.py
@@ -92,8 +92,9 @@ class CaptureDevice(object):
         """
         if self.instance is not None:
             with self.lock:
-                _cvcapture.lib.cvclose(self.instance)
-            self.instance = None
+                if self.instance is not None:
+                    _cvcapture.lib.cvclose(self.instance)
+                    self.instance = None
 
     __del__ = close
 


### PR DESCRIPTION
This fixes two issues, both of which would lead to us calling `cvclose` on an already closed camera:
- it was possible to leave the lock before assigning `self.instance` to `None` (meaning that the `is not None` check we had could be bypassed trivially)
- it was possible to enter the lock when `self.instance` was actually `None` if that assignment happened between the check and getting the lock (note that this is separate from the above). This isn't preventable though we can guard against its effect by re-checking `self.instance` inside the locked region