### PR TITLE
Update opencv dependencies for stretch

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,8 +25,8 @@ Depends: ${misc:Depends},
          python3,
          ${python3:Depends},
          libcv2.4,
-         libopencv-photo2.4,
-         libopencv-contrib2.4,
+         libopencv-photo2.4v5,
+         libopencv-contrib2.4v5,
 Description: SourceBots vision subsystem
  Processes images from input streams such as cameras and produces
  information on fiducial markers found within them.


### PR DESCRIPTION
The package names have changed.

Do we want to spell this such that we support both Jessie and Stretch?