### PR TITLE
Also throw away some frames before each capture

### DIFF
--- a/sb_vision/native/cvcapture.cpp
+++ b/sb_vision/native/cvcapture.cpp
@@ -66,10 +66,13 @@ int cvcapture(void* context, void* buffer, size_t width, size_t height) {
     else {
         // To be sure that we get an image which accurately describes what is in
         // front of the camera _right now_ (rather than whenever the last frames
-        // were grabbed) we ditch the last 3 frames.
+        // were grabbed) we ditch the last few frames.
         // This is needed with the TeckNet cameras we're using, though may not
-        // be needed for others.
-        skipframes(cap, 3);
+        // be needed for others. Note: manual testing suggests that skipping 4
+        // frames works for this purpose, though we deliberatly skip one more
+        // than that to reduce the chances that we'll get a bad frame (in case
+        // this is timing related).
+        skipframes(cap, 5);
     }
 
     if (cap->get(CV_CAP_PROP_FRAME_WIDTH) != (double)width) {


### PR DESCRIPTION
See inline comment for details.

I've tested this using my Pi 3, running the current versions of `robotd` and `robot-api` at the time of writing (https://github.com/sourcebots/robotd/commit/9123954 and sourcebots/robot-api@16aff76), using the following (rough) procedure:

0. Setup:
    * install `sb-vision`, `robotd` & `robot-api`
    * setup the camera so it's pointing at a marker, validate that it detects the marker
    * prepare something to block the camera's vision, ideally something you can leave in place (i.e: _not_ your hand), validate that this causes the camera _not_ to see the marker
1. (re)build & (re)install `sb-vision` with changes
2. run local robotd (I don't have a power board; it's likely that if you do then just using the service one would probably work fine): `/usr/bin/python3 -u -m robotd.master --root-dir /tmp/robotd`
3. run a python shell (I used a single instance of an `ipython` shell for all the testing), into which `from robot.camera import Camera`
4. In the python shell, grab a camera instance `cam = Camera('/tmp/robotd/camera/video0')`
5. Trigger image capture with `cam.see()` and look at the output:
    1. Grab a couple of unobscured frames to start with (thus checking that everything still works and that the warm-up behaves as expected)
    2. Cover the camera
    3. Wait 20 seconds
    4. Take another frame. Test pass if (and only if) this returns no markers
    5. Wait 20 seconds
    6. Uncover the camera
    7. Take another frame. Test pass if (and only if) this returns the same markers as in the initial frames

I'm reasonably sure that you could use the `debug` command (in its looping mode) and then just eyeball the resulting images, though as I was already testing the full stack it seemed reasonable to continue using what I already set up there. I'm mostly documenting what I did here for reproducibility later if needed.

Note: I've _not_ looked at whether this means that we can reduce the number of frames skipped during the `warmup` phase. It likely means we can, though it's not quite trivial since we use the `warmup` function after changing resolutions too.