### PR TITLE
Implement valid coordinate conversion

### DIFF
--- a/sb_vision/__init__.py
+++ b/sb_vision/__init__.py
@@ -7,6 +7,7 @@ of AprilTags markers.
 """
 
 from .camera import Camera, FileCamera
+from .coordinates import Polar, cartesian_to_polar, Cartesian
 from .tokens import Token
 from .vision import Vision
 
@@ -15,4 +16,7 @@ __all__ = [
     'Camera',
     'FileCamera',
     'Token',
+    'Cartesian',
+    'Polar',
+    'cartesian_to_polar',
 ]

--- a/sb_vision/__init__.py
+++ b/sb_vision/__init__.py
@@ -7,7 +7,7 @@ of AprilTags markers.
 """
 
 from .camera import Camera, FileCamera
-from .coordinates import Polar, cartesian_to_polar, Cartesian
+from .coordinates import Cartesian, LegacyPolar, Spherical, cartesian_to_spherical
 from .tokens import Token
 from .vision import Vision
 
@@ -17,6 +17,7 @@ __all__ = [
     'FileCamera',
     'Token',
     'Cartesian',
-    'Polar',
-    'cartesian_to_polar',
+    'LegacyPolar',
+    'Spherical',
+    'cartesian_to_spherical',
 ]

--- a/sb_vision/cli/debug.py
+++ b/sb_vision/cli/debug.py
@@ -1,6 +1,7 @@
 """Debug code, load the first video device seen and capture an image."""
 
 import contextlib
+import math
 import pathlib
 
 from ..camera import Camera, CameraBase, FileCamera  # noqa: F401
@@ -36,6 +37,11 @@ def _capture_and_display_image(
         print("- {}".format(token))
         try:
             print("  x: {0:.3f}m, y: {1:.3f}m, z: {2:.3f}m".format(*token.cartesian))
+            print("  rot_x: {0:.3f}°, rot_y: {1:.3f}°, dist: {2:.3f}m".format(
+                math.degrees(token.polar.rot_x),
+                math.degrees(token.polar.rot_y),
+                token.polar.dist,
+            ))
         except AttributeError:
             pass
 

--- a/sb_vision/coordinates.py
+++ b/sb_vision/coordinates.py
@@ -6,11 +6,22 @@ from numpy import arctan2, float64, linalg
 
 AnyFloat = Union[float, float64]
 
-Cartesian = NamedTuple('Cartesian', (
+_Cartesian = NamedTuple('Cartesian', (
     ('x', AnyFloat),
     ('y', AnyFloat),
     ('z', AnyFloat),
 ))
+
+
+class Cartesian(_Cartesian):
+    """Cartesian coordinates."""
+
+    __slots__ = ()
+
+    def tolist(self):
+        """Placeholder helper to ease migration within robotd."""
+        return list(self)
+
 
 Polar = NamedTuple('Polar', (
     ('rot_x', AnyFloat),

--- a/sb_vision/coordinates.py
+++ b/sb_vision/coordinates.py
@@ -1,0 +1,29 @@
+"""Types and helpers for manipulating coordinates."""
+
+from typing import NamedTuple, Union
+
+from numpy import arctan2, float64, linalg
+
+AnyFloat = Union[float, float64]
+
+Cartesian = NamedTuple('Cartesian', (
+    ('x', AnyFloat),
+    ('y', AnyFloat),
+    ('z', AnyFloat),
+))
+
+Polar = NamedTuple('Polar', (
+    ('rot_x', AnyFloat),
+    ('rot_y', AnyFloat),
+    ('dist', AnyFloat),
+))
+
+
+def cartesian_to_polar(cartesian: Cartesian) -> Polar:
+    """Convert a Cartesian coordinate into a polar one."""
+    x, y, z = cartesian
+    return Polar(
+        rot_x=arctan2(y, z),
+        rot_y=arctan2(x, z),
+        dist=linalg.norm(cartesian),
+    )

--- a/sb_vision/coordinates.py
+++ b/sb_vision/coordinates.py
@@ -2,6 +2,7 @@
 
 from typing import NamedTuple, Union
 
+import numpy as np
 from numpy import arctan2, float64, linalg
 
 AnyFloat = Union[float, float64]
@@ -23,18 +24,37 @@ class Cartesian(_Cartesian):
         return list(self)
 
 
-Polar = NamedTuple('Polar', (
+Spherical = NamedTuple('Spherical', (
     ('rot_x', AnyFloat),
     ('rot_y', AnyFloat),
     ('dist', AnyFloat),
 ))
 
+LegacyPolar = NamedTuple('LegacyPolar', (
+    ('polar_x', AnyFloat),
+    ('polar_y', AnyFloat),
+    ('dist', AnyFloat),
+))
 
-def cartesian_to_polar(cartesian: Cartesian) -> Polar:
-    """Convert a Cartesian coordinate into a polar one."""
+
+def cartesian_to_spherical(cartesian: Cartesian) -> Spherical:
+    """Convert a Cartesian coordinate into a spherical one."""
     x, y, z = cartesian
-    return Polar(
+    return Spherical(
         rot_x=arctan2(y, z),
         rot_y=arctan2(x, z),
         dist=linalg.norm(cartesian),
     )
+
+
+def cartesian_to_legacy_polar(cartesian: Cartesian) -> LegacyPolar:
+    """
+    Convert cartesian co-ordinate space to the legacy "polar" space.
+
+    This is kept for compatibilty only.
+    """
+    cart_x, cart_y, cart_z = tuple(cartesian)
+    polar_dist = np.linalg.norm(cartesian)
+    polar_x = np.arctan2(cart_z, cart_x)
+    polar_y = np.arctan2(cart_z, cart_y)
+    return LegacyPolar(polar_x, polar_y, polar_dist)

--- a/sb_vision/tokens.py
+++ b/sb_vision/tokens.py
@@ -11,7 +11,7 @@ import numpy as np
 from .coordinates import (
     Cartesian,
     cartesian_to_legacy_polar,
-    cartesian_to_spherical
+    cartesian_to_spherical,
 )
 
 if TYPE_CHECKING:

--- a/sb_vision/tokens.py
+++ b/sb_vision/tokens.py
@@ -8,7 +8,11 @@ from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple
 
 import numpy as np
 
-from .coordinates import Cartesian, cartesian_to_polar
+from .coordinates import (
+    Cartesian,
+    cartesian_to_legacy_polar,
+    cartesian_to_spherical
+)
 
 if TYPE_CHECKING:
     # Interface-only definitions
@@ -215,7 +219,10 @@ class Token:
         )
 
         # Polar co-ordinates in the 3D world, relative to the camera
-        self.polar = cartesian_to_polar(self.cartesian)
+        self.polar = cartesian_to_legacy_polar(self.cartesian)
+        self.legacy_polar = cartesian_to_legacy_polar(self.cartesian)
+
+        self.spherical = cartesian_to_spherical(self.cartesian)
 
     def __repr__(self) -> str:
         """General debug representation."""

--- a/sb_vision/tokens.py
+++ b/sb_vision/tokens.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple
 
 import numpy as np
 
+from .coordinates import Cartesian, cartesian_to_polar
+
 if TYPE_CHECKING:
     # Interface-only definitions
     from .native.apriltag.types import ApriltagDetection  # noqa: F401
@@ -128,7 +130,7 @@ def _get_cartesian(
     homography_matrix,
     image_size: Tuple[int, int],
     distance_model: str,
-):
+) -> Cartesian:
     calibration = _get_distance_model(distance_model, image_size)
 
     x = _apply_distance_model_component_to_homography_matrix(
@@ -141,7 +143,7 @@ def _get_cartesian(
         homography_matrix,
     )  # type: np.float64
 
-    return np.array([x, y, z])
+    return Cartesian(x, y, z)
 
 
 class Token:
@@ -156,15 +158,6 @@ class Token:
         """
         self.id = id
         self.certainty = certainty
-
-    @staticmethod
-    def cartesian_to_polar(cartesian):
-        """Convert cartesian co-ordinate space to polar."""
-        cart_x, cart_y, cart_z = tuple(cartesian)
-        polar_dist = np.linalg.norm(cartesian)
-        polar_x = np.arctan2(cart_z, cart_x)
-        polar_y = np.arctan2(cart_z, cart_y)
-        return polar_x, polar_y, polar_dist
 
     @classmethod
     def from_apriltag_detection(
@@ -222,7 +215,7 @@ class Token:
         )
 
         # Polar co-ordinates in the 3D world, relative to the camera
-        self.polar = self.cartesian_to_polar(self.cartesian)
+        self.polar = cartesian_to_polar(self.cartesian)
 
     def __repr__(self) -> str:
         """General debug representation."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,9 @@ max_line_length = 90
 [isort]
 atomic = true
 balanced_wrapping = true
+# vertical hanging indent style wrapping
 multi_line_output = 3
+include_trailing_comma = true
 
 known_first_party = sb_vision
 default_section = THIRDPARTY

--- a/tests/test_coordinate_conversion.py
+++ b/tests/test_coordinate_conversion.py
@@ -4,12 +4,12 @@ import math
 
 import pytest
 
-from sb_vision import Cartesian, Polar, cartesian_to_polar
+from sb_vision import Cartesian, Spherical, cartesian_to_spherical
 
 TEST_DATA = [
     (
         Cartesian(x=0, y=0, z=1),
-        Polar(
+        Spherical(
             rot_x=0,
             rot_y=0,
             dist=1,
@@ -17,7 +17,7 @@ TEST_DATA = [
     ),
     (
         Cartesian(x=0, y=1, z=1),
-        Polar(
+        Spherical(
             rot_x=math.pi / 4,  # or 45 degrees
             rot_y=0,
             dist=2**0.5,  # or 1.4142135623730951
@@ -25,7 +25,7 @@ TEST_DATA = [
     ),
     (
         Cartesian(x=1, y=0, z=1),
-        Polar(
+        Spherical(
             rot_x=0,
             rot_y=math.pi / 4,  # or 45 degrees
             dist=2**0.5,  # or 1.4142135623730951
@@ -33,7 +33,7 @@ TEST_DATA = [
     ),
     (
         Cartesian(x=1, y=1, z=1),
-        Polar(
+        Spherical(
             rot_x=math.pi / 4,  # or 45 degrees
             rot_y=math.pi / 4,  # or 45 degrees
             dist=3**0.5,  # or 1.7320508075688772
@@ -41,7 +41,7 @@ TEST_DATA = [
     ),
     (
         Cartesian(x=-1, y=1, z=1),
-        Polar(
+        Spherical(
             rot_x=math.pi / 4,  # or -45 degrees
             rot_y=-math.pi / 4,  # or 45 degrees
             dist=3**0.5,  # or 1.7320508075688772
@@ -49,7 +49,7 @@ TEST_DATA = [
     ),
     (
         Cartesian(x=1, y=-1, z=1),
-        Polar(
+        Spherical(
             rot_x=-math.pi / 4,  # or -45 degrees
             rot_y=math.pi / 4,  # or 45 degrees
             dist=3**0.5,  # or 1.7320508075688772
@@ -57,7 +57,7 @@ TEST_DATA = [
     ),
     (
         Cartesian(x=-0.1, y=0, z=1),
-        Polar(
+        Spherical(
             rot_x=0,
             rot_y=math.atan(-0.1),  # or -5.710593137499643 degrees
             dist=(0.01 + 1)**0.5,  # or 1.004987562112089
@@ -65,7 +65,7 @@ TEST_DATA = [
     ),
     (
         Cartesian(x=-0.9, y=0, z=3),
-        Polar(
+        Spherical(
             rot_x=0,
             rot_y=math.atan(-0.9 / 3),  # or -16.69924423399362 degrees
             dist=(0.81 + 9)**0.5,  # or 3.132091952673165
@@ -73,7 +73,7 @@ TEST_DATA = [
     ),
     (
         Cartesian(x=0, y=-0.1, z=3),
-        Polar(
+        Spherical(
             rot_x=math.atan(-0.1 / 3),  # or -1.9091524329963763 degrees
             rot_y=0,
             dist=(0.01 + 9)**0.5,  # or 3.132091952673165
@@ -82,11 +82,11 @@ TEST_DATA = [
 ]
 
 
-@pytest.mark.parametrize("cartesian, polar", TEST_DATA)
-def test_cartesian_to_polar(cartesian, polar):
+@pytest.mark.parametrize("cartesian, spherical", TEST_DATA)
+def test_cartesian_to_spherical(cartesian, spherical):
     """Make sure that this conversion works."""
-    actual = cartesian_to_polar(cartesian)
+    actual = cartesian_to_spherical(cartesian)
 
-    assert round(polar.rot_x, 3) == round(actual.rot_x, 3), "Wrong x rotation"
-    assert round(polar.rot_y, 3) == round(actual.rot_y, 3), "Wrong y rotation"
-    assert round(polar.dist, 3) == round(actual.dist, 3), "Wrong distance"
+    assert round(spherical.rot_x, 3) == round(actual.rot_x, 3), "Wrong x rotation"
+    assert round(spherical.rot_y, 3) == round(actual.rot_y, 3), "Wrong y rotation"
+    assert round(spherical.dist, 3) == round(actual.dist, 3), "Wrong distance"

--- a/tests/test_coordinate_conversion.py
+++ b/tests/test_coordinate_conversion.py
@@ -1,0 +1,92 @@
+"""Test that our coordinate conversions work."""
+
+import math
+
+import pytest
+
+from sb_vision import Cartesian, Polar, cartesian_to_polar
+
+TEST_DATA = [
+    (
+        Cartesian(x=0, y=0, z=1),
+        Polar(
+            rot_x=0,
+            rot_y=0,
+            dist=1,
+        ),
+    ),
+    (
+        Cartesian(x=0, y=1, z=1),
+        Polar(
+            rot_x=math.pi / 4,  # or 45 degrees
+            rot_y=0,
+            dist=2**0.5,  # or 1.4142135623730951
+        ),
+    ),
+    (
+        Cartesian(x=1, y=0, z=1),
+        Polar(
+            rot_x=0,
+            rot_y=math.pi / 4,  # or 45 degrees
+            dist=2**0.5,  # or 1.4142135623730951
+        ),
+    ),
+    (
+        Cartesian(x=1, y=1, z=1),
+        Polar(
+            rot_x=math.pi / 4,  # or 45 degrees
+            rot_y=math.pi / 4,  # or 45 degrees
+            dist=3**0.5,  # or 1.7320508075688772
+        ),
+    ),
+    (
+        Cartesian(x=-1, y=1, z=1),
+        Polar(
+            rot_x=math.pi / 4,  # or -45 degrees
+            rot_y=-math.pi / 4,  # or 45 degrees
+            dist=3**0.5,  # or 1.7320508075688772
+        ),
+    ),
+    (
+        Cartesian(x=1, y=-1, z=1),
+        Polar(
+            rot_x=-math.pi / 4,  # or -45 degrees
+            rot_y=math.pi / 4,  # or 45 degrees
+            dist=3**0.5,  # or 1.7320508075688772
+        ),
+    ),
+    (
+        Cartesian(x=-0.1, y=0, z=1),
+        Polar(
+            rot_x=0,
+            rot_y=math.atan(-0.1),  # or -5.710593137499643 degrees
+            dist=(0.01 + 1)**0.5,  # or 1.004987562112089
+        ),
+    ),
+    (
+        Cartesian(x=-0.9, y=0, z=3),
+        Polar(
+            rot_x=0,
+            rot_y=math.atan(-0.9 / 3),  # or -16.69924423399362 degrees
+            dist=(0.81 + 9)**0.5,  # or 3.132091952673165
+        ),
+    ),
+    (
+        Cartesian(x=0, y=-0.1, z=3),
+        Polar(
+            rot_x=math.atan(-0.1 / 3),  # or -1.9091524329963763 degrees
+            rot_y=0,
+            dist=(0.01 + 9)**0.5,  # or 3.132091952673165
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize("cartesian, polar", TEST_DATA)
+def test_cartesian_to_polar(cartesian, polar):
+    """Make sure that this conversion works."""
+    actual = cartesian_to_polar(cartesian)
+
+    assert round(polar.rot_x, 3) == round(actual.rot_x, 3), "Wrong x rotation"
+    assert round(polar.rot_y, 3) == round(actual.rot_y, 3), "Wrong y rotation"
+    assert round(polar.dist, 3) == round(actual.dist, 3), "Wrong distance"

--- a/tests/test_coordinates_from_file.py
+++ b/tests/test_coordinates_from_file.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from sb_vision import Cartesian, FileCamera, Polar, Vision
+from sb_vision import Cartesian, FileCamera, LegacyPolar, Spherical, Vision
 
 CALIBRATIONS = Path(__file__).parent.parent / 'calibrations' / 'c270'
 
@@ -13,7 +13,12 @@ TEST_IMAGES = [
     (
         '100cmL10cm.jpg',
         Cartesian(x=-0.1, y=0, z=1),
-        Polar(
+        LegacyPolar(
+            polar_x=1.6704649792860642,
+            polar_y=1.5707963267948966,
+            dist=1.004987562112089,
+        ),
+        Spherical(
             rot_x=0,
             rot_y=math.atan(-0.1),  # or -5.710593137499643 degrees
             dist=(0.01 + 1)**0.5,  # or 1.004987562112089
@@ -22,7 +27,12 @@ TEST_IMAGES = [
     (
         '300cmL90cm.jpg',
         Cartesian(x=-0.9, y=0, z=3),
-        Polar(
+        LegacyPolar(
+            polar_x=1.8622531212727658,
+            polar_y=1.5707963267948966,
+            dist=3.132091952673165,
+        ),
+        Spherical(
             rot_x=0,
             rot_y=math.atan(-0.9 / 3),  # or -16.69924423399362 degrees
             dist=(0.81 + 9)**0.5,  # or 3.132091952673165
@@ -31,8 +41,11 @@ TEST_IMAGES = [
 ]
 
 
-@pytest.mark.parametrize("photo, expected_cartesian, expected_polar", TEST_IMAGES)
-def test_image_coordinates(photo, expected_cartesian, expected_polar):
+@pytest.mark.parametrize(
+    "photo, expected_cartesian, expected_polar, expected_spherical",
+    TEST_IMAGES,
+)
+def test_image_coordinates(photo, expected_cartesian, expected_polar, expected_spherical):
     """Make sure that this particular file gives these particular tokens."""
     camera = FileCamera(CALIBRATIONS / photo, distance_model='c270')
     vision = Vision(camera)
@@ -44,8 +57,14 @@ def test_image_coordinates(photo, expected_cartesian, expected_polar):
     assert expected_cartesian.y == round(y, 3), "Wrong y-coordinate"
     assert expected_cartesian.z == round(z, 3), "Wrong z-coordinate"
 
-    rot_x, rot_y, dist = token.polar
+    polar_x, polar_y, dist = token.legacy_polar
 
-    assert expected_polar.rot_x == round(rot_x, 3), "Wrong x rotation"
-    assert round(expected_polar.rot_y, 3) == round(rot_y, 3), "Wrong y rotation"
+    assert round(expected_polar.polar_x, 3) == round(polar_x, 3), "Wrong x angle"
+    assert round(expected_polar.polar_y, 3) == round(polar_y, 3), "Wrong y angle"
     assert round(expected_polar.dist, 3) == round(dist, 3), "Wrong distance"
+
+    rot_x, rot_y, dist = token.spherical
+
+    assert expected_spherical.rot_x == round(rot_x, 3), "Wrong x rotation"
+    assert round(expected_spherical.rot_y, 3) == round(rot_y, 3), "Wrong y rotation"
+    assert round(expected_spherical.dist, 3) == round(dist, 3), "Wrong distance"

--- a/tests/test_coordinates_from_file.py
+++ b/tests/test_coordinates_from_file.py
@@ -1,0 +1,51 @@
+"""Integration tests for coordinates."""
+
+import math
+from pathlib import Path
+
+import pytest
+
+from sb_vision import Cartesian, FileCamera, Polar, Vision
+
+CALIBRATIONS = Path(__file__).parent.parent / 'calibrations' / 'c270'
+
+TEST_IMAGES = [
+    (
+        '100cmL10cm.jpg',
+        Cartesian(x=-0.1, y=0, z=1),
+        Polar(
+            rot_x=0,
+            rot_y=math.atan(-0.1),  # or -5.710593137499643 degrees
+            dist=(0.01 + 1)**0.5,  # or 1.004987562112089
+        ),
+    ),
+    (
+        '300cmL90cm.jpg',
+        Cartesian(x=-0.9, y=0, z=3),
+        Polar(
+            rot_x=0,
+            rot_y=math.atan(-0.9 / 3),  # or -16.69924423399362 degrees
+            dist=(0.81 + 9)**0.5,  # or 3.132091952673165
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize("photo, expected_cartesian, expected_polar", TEST_IMAGES)
+def test_image_coordinates(photo, expected_cartesian, expected_polar):
+    """Make sure that this particular file gives these particular tokens."""
+    camera = FileCamera(CALIBRATIONS / photo, distance_model='c270')
+    vision = Vision(camera)
+    token, = vision.snapshot()
+
+    x, y, z = token.cartesian
+
+    assert expected_cartesian.x == round(x, 3), "Wrong x-coordinate"
+    assert expected_cartesian.y == round(y, 3), "Wrong y-coordinate"
+    assert expected_cartesian.z == round(z, 3), "Wrong z-coordinate"
+
+    rot_x, rot_y, dist = token.polar
+
+    assert expected_polar.rot_x == round(rot_x, 3), "Wrong x rotation"
+    assert round(expected_polar.rot_y, 3) == round(rot_y, 3), "Wrong y rotation"
+    assert round(expected_polar.dist, 3) == round(dist, 3), "Wrong distance"


### PR DESCRIPTION
Replace the coordinate conversion helper with one which conforms to the usual meanings of polar coordinates and introduce typed named tuples for the coordinate systems so that we get useful representations.

This also adds tests: both unit tests for the conversion util and integration tests that we get the right values for some example images.