### PR TITLE
make pytest truly optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,12 @@
+import sys
+
 from setuptools import find_packages, setup
+
+# make pytest-runner be required only when needed
+# This means pytest definitely isn't a dependency if tests aren't run.
+needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
+pytest_runner = ['pytest-runner'] if needs_pytest else []
+
 
 setup(
     name='sb-vision',
@@ -10,8 +18,7 @@ setup(
     include_package_data=True,
     setup_requires=[
         'cffi>=1.4.0',
-        'pytest-runner',
-    ],
+    ] + pytest_runner,
     cffi_modules=[
         'sb_vision/native/cvcapture_build.py:ffibuilder',
         'sb_vision/native/apriltag/apriltag_build.py:ffi',


### PR DESCRIPTION
`pytest` isn't a dependency for the project.

However, if one runs `setup.py install`, it will also install pytest, as it's a requirement for `pytest-runner`, which itself needs to be a setup dependency for `python setup.py test` to call `pytest`.

This PR implements the recommended workaround (see https://pypi.python.org/pypi/pytest-runner#considerations consdierations section) to `setup.py` to make it only be in `setup_requires` when needed.