### PR TITLE
Wrap solvePnP directly

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,6 +15,7 @@ Build-Depends: debhelper (>= 9),
                libcv-dev,
                libffi-dev,
                libopencv-photo-dev,
+               libopencv-calib3d-dev,
                libopencv-contrib-dev,
 Standards-Version: 3.9.6
 
@@ -26,6 +27,7 @@ Depends: ${misc:Depends},
          ${python3:Depends},
          libcv2.4,
          libopencv-photo2.4v5,
+         libopencv-calib3d2.4v5,
          libopencv-contrib2.4v5,
 Description: SourceBots vision subsystem
  Processes images from input streams such as cameras and produces

--- a/sb_vision/cv3d.py
+++ b/sb_vision/cv3d.py
@@ -31,7 +31,7 @@ def _ffi_flattened_float_array(values: Sequence[Sequence[float]]):
     flattened_values = sum([tuple(x) for x in values], ())
     count = len(values) * lengths[0]
 
-    return _cv3d.ffi.new('float[{}]'.format(count), flattened_values)
+    return _cv3d.ffi.new('double[{}]'.format(count), flattened_values)
 
 
 def solve_pnp(

--- a/sb_vision/cv3d.py
+++ b/sb_vision/cv3d.py
@@ -1,0 +1,72 @@
+"""
+Python wrapping around cffi layer to interop to OpenCV 3D functions.
+"""
+
+from typing import Sequence, Tuple
+
+from sb_vision.native import _cv3d  # type: ignore
+
+from .coordinates import Cartesian, PixelCoordinate
+
+
+class Cv3dError(RuntimeError):
+    """A 3D related OpenCV error."""
+
+    pass
+
+
+def _ffi_flattened_float_array(values: Sequence[Sequence[float]]):
+    if not values:
+        raise ValueError("Refusing to create ffi matrix for empty 'values'.")
+
+    lengths = list({len(x) for x in values})
+    if len(lengths) != 1:
+        raise ValueError(
+            "'values' is not rectangular (got row lengths of {} and {})".format(
+                ", ".join(str(x) for x in lengths[:-1]),
+                lengths[-1],
+            ),
+        )
+
+    flattened_values = sum([tuple(x) for x in values], ())
+    count = len(values) * lengths[0]
+
+    return _cv3d.ffi.new('float[{}]'.format(count), flattened_values)
+
+
+def solve_pnp(
+    object_points: Sequence[Sequence[float]],
+    pixel_corners: Sequence[PixelCoordinate],
+    camera_matrix: Sequence[Sequence[float]],
+    distance_coefficients: Sequence[Sequence[float]],
+) -> Tuple[Cartesian, Tuple[float, float, float]]:
+    """
+    Wrapper around OpenCV solvePnP.
+
+    See the OpenCV docs for details.
+    """
+    # https://docs.opencv.org/2.4/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html#solvepnp
+    # https://docs.opencv.org/master/d9/d0c/group__calib3d.html#ga549c2075fac14829ff4a58bc931c033d
+
+    orientation_vector = _cv3d.ffi.new('double[3]')
+    translation_vector = _cv3d.ffi.new('double[3]')
+
+    return_value = _cv3d.lib.solve_pnp(
+        _ffi_flattened_float_array(object_points),
+        _ffi_flattened_float_array(pixel_corners),
+        _ffi_flattened_float_array(camera_matrix),
+        _ffi_flattened_float_array(distance_coefficients),
+        orientation_vector,
+        translation_vector,
+    )
+    if not return_value:
+        raise Cv3dError("OpenCV solvePnP failed")
+
+    return (
+        Cartesian(*translation_vector),
+        (
+            float(orientation_vector[0]),
+            float(orientation_vector[1]),
+            float(orientation_vector[2]),
+        ),
+    )

--- a/sb_vision/find_3D_coords.py
+++ b/sb_vision/find_3D_coords.py
@@ -8,13 +8,13 @@ location finding function.
 import functools
 import re
 from pathlib import Path
-from typing import List, Tuple, cast
+from typing import List, Sequence, Tuple, cast
 
-import cv2
 import numpy as np
 from lxml import etree
 
 from sb_vision.coordinates import Cartesian, PixelCoordinate
+from sb_vision.native import _cv3d
 
 
 def _get_values_from_xml_element(element: etree.Element) -> List[str]:
@@ -83,6 +83,25 @@ def load_camera_calibrations(camera_model: str) -> Tuple[List[List[float]],
     return camera_matrix, distance_coefficients
 
 
+def ffi_float_matrix(values: Sequence[Sequence[float]]):
+    if not values:
+        raise ValueError("Refusing to create ffi matrix for empty 'values'.")
+
+    lengths = list(set(len(x) for x in values))
+    if len(lengths) != 1:
+        raise ValueError(
+            "'values' is not rectangular (got row lengths of {} and {})".format(
+                ", ".join(str(x) for x in lengths[:-1]),
+                lengths[-1],
+            ),
+        )
+
+    flattened_values = sum([tuple(x) for x in values], ())
+    count = len(values) * lengths[0]
+
+    return _cv3d.ffi.new('float[{}]'.format(count), flattened_values)
+
+
 def calculate_transforms(
     marker_size: Tuple[float, float],
     pixel_corners: List[PixelCoordinate],
@@ -107,33 +126,29 @@ def calculate_transforms(
     height_from_centre = h / 2
 
     # create the rectangle representing the marker in 3D
-    object_points = np.array([
+    object_points = ffi_float_matrix([
         [width_from_centre, height_from_centre, 0],
         [width_from_centre, -height_from_centre, 0],
         [-width_from_centre, -height_from_centre, 0],
         [-width_from_centre, height_from_centre, 0],
     ])
 
-    return_value, orientation_vector, translation_vector = cv2.solvePnP(
+    orientation_vector = ffi_float_matrix([[0] * 3])
+    translation_vector = ffi_float_matrix([[0] * 3])
+
+    return_value = _cv3d.lib.solve_pnp(
         object_points,
-        np.array(pixel_corners),
-        np.array(camera_matrix),
-        np.array(distance_coefficients),
+        ffi_float_matrix(pixel_corners),
+        ffi_float_matrix(camera_matrix),
+        ffi_float_matrix(distance_coefficients),
+        orientation_vector,
+        translation_vector,
     )
     if not return_value:
         raise ValueError("cv2.solvePnP returned false")
 
-    translation_vector = Cartesian(*(v[0] for v in translation_vector))
-    # OpenCV returns co-ordinates where a positive Y is downwards
-    translation_vector = Cartesian(
-        translation_vector.x,
-        -translation_vector.y,
-        translation_vector.z,
-    )
+    translation_vector = Cartesian(*translation_vector)
 
-    orientation_vector = cast(
-        Tuple[float, float, float],
-        tuple(v[0] for v in orientation_vector),
-    )
+    orientation_vector = tuple(orientation_vector)
 
     return translation_vector, orientation_vector

--- a/sb_vision/native/cv3d.cpp
+++ b/sb_vision/native/cv3d.cpp
@@ -68,6 +68,7 @@ int solve_pnp(
     // printf("camera_matrix: "); print_array(3, 3, camera_matrix);
     // printf("dist_coeffs: "); print_array(5, 1, dist_coeffs);
 
+    // Copy our input data into OpenCV's Mat wrapper
     cv::Mat object_points_mat(4, 3, CV_64FC1);
     COPY_INTO(object_points_mat, object_points);
 
@@ -85,6 +86,7 @@ int solve_pnp(
     // printf("camera_matrix_mat: "); print_mat(camera_matrix_mat);
     // printf("dist_coeffs_mat: "); print_mat(dist_coeffs_mat);
 
+    // These are our output data
     cv::Mat rvec_mat, tvec_mat;
 
     bool ret = cv::solvePnP(
@@ -99,6 +101,7 @@ int solve_pnp(
     // printf("rvec_mat: "); print_mat(rvec_mat);
     // printf("tvec_mat: "); print_mat(tvec_mat);
 
+    // Copy the output data out of OpenCV's wrappers
     memcpy(rvec, rvec_mat.ptr(), 3 * sizeof(double));
     memcpy(tvec, tvec_mat.ptr(), 3 * sizeof(double));
 

--- a/sb_vision/native/cv3d.cpp
+++ b/sb_vision/native/cv3d.cpp
@@ -11,8 +11,8 @@ extern "C" {
         const float image_points[],
         const float camera_matrix[],
         const float dist_coeffs[],
-        float rvec[],
-        float tvec[]
+        double rvec[],
+        double tvec[]
     );
 }
 
@@ -60,8 +60,8 @@ int solve_pnp(
     const float image_points[],
     const float camera_matrix[],
     const float dist_coeffs[],
-    float rvec[],
-    float tvec[]
+    double rvec[],
+    double tvec[]
 ) {
     // printf("object_points: "); print_array(4, 3, object_points);
     // printf("image_points: "); print_array(4, 2, image_points);
@@ -96,16 +96,8 @@ int solve_pnp(
         tvec_mat_double
     );
 
-    // Convert back to floats (solvePnP gives us doubles)
-    cv::Mat rvec_mat, tvec_mat;
-    rvec_mat_double.convertTo(rvec_mat, CV_32FC1);
-    tvec_mat_double.convertTo(tvec_mat, CV_32FC1);
-
-    // printf("rvec_mat: "); print_mat(rvec_mat_double);
-    // printf("tvec_mat: "); print_mat(tvec_mat_double);
-
-    memcpy(rvec, rvec_mat.ptr(), 3 * sizeof(float));
-    memcpy(tvec, tvec_mat.ptr(), 3 * sizeof(float));
+    memcpy(rvec, rvec_mat_double.ptr(), 3 * sizeof(double));
+    memcpy(tvec, tvec_mat_double.ptr(), 3 * sizeof(double));
 
     // printf("rvec: "); print_array(3, 1, rvec);
     // printf("tvec: "); print_array(3, 1, tvec);

--- a/sb_vision/native/cv3d.cpp
+++ b/sb_vision/native/cv3d.cpp
@@ -85,19 +85,19 @@ int solve_pnp(
     // printf("camera_matrix_mat: "); print_mat(camera_matrix_mat);
     // printf("dist_coeffs_mat: "); print_mat(dist_coeffs_mat);
 
-    cv::Mat rvec_mat_double, tvec_mat_double;
+    cv::Mat rvec_mat, tvec_mat;
 
     bool ret = cv::solvePnP(
         object_points_mat,
         image_points_mat,
         camera_matrix_mat,
         dist_coeffs_mat,
-        rvec_mat_double,
-        tvec_mat_double
+        rvec_mat,
+        tvec_mat
     );
 
-    memcpy(rvec, rvec_mat_double.ptr(), 3 * sizeof(double));
-    memcpy(tvec, tvec_mat_double.ptr(), 3 * sizeof(double));
+    memcpy(rvec, rvec_mat.ptr(), 3 * sizeof(double));
+    memcpy(tvec, tvec_mat.ptr(), 3 * sizeof(double));
 
     // printf("rvec: "); print_array(3, 1, rvec);
     // printf("tvec: "); print_array(3, 1, tvec);

--- a/sb_vision/native/cv3d.cpp
+++ b/sb_vision/native/cv3d.cpp
@@ -96,6 +96,9 @@ int solve_pnp(
         tvec_mat
     );
 
+    // printf("rvec_mat: "); print_mat(rvec_mat);
+    // printf("tvec_mat: "); print_mat(tvec_mat);
+
     memcpy(rvec, rvec_mat.ptr(), 3 * sizeof(double));
     memcpy(tvec, tvec_mat.ptr(), 3 * sizeof(double));
 

--- a/sb_vision/native/cv3d.cpp
+++ b/sb_vision/native/cv3d.cpp
@@ -35,6 +35,7 @@ void print_array(const int rows, const int cols, const float values[]) {
 }
 
 void print_mat(cv::Mat& mat) {
+    printf("(%d x %d = %d) ", mat.rows, mat.cols, mat.total());
     printf("[\n");
     for (int i=0; i<mat.rows; i++) {
         printf("  [");

--- a/sb_vision/native/cv3d.cpp
+++ b/sb_vision/native/cv3d.cpp
@@ -18,6 +18,10 @@ extern "C" {
 
 #include "opencv2/opencv.hpp"
 
+#define COPY_INTO(mat, data) \
+    memcpy(mat.ptr(), data, mat.rows * mat.cols * sizeof(float));
+
+
 int solve_pnp(
     const float object_points[],
     const float image_points[],
@@ -26,10 +30,17 @@ int solve_pnp(
     float rvec[],
     float tvec[]
 ) {
-    cv::Mat object_points_mat(4, 3, CV_32FC1, &object_points);
-    cv::Mat image_points_mat(4, 2, CV_32FC1, &image_points);
-    cv::Mat camera_matrix_mat(3, 3, CV_32FC1, &camera_matrix);
-    cv::Mat dist_coeffs_mat(5, 1, CV_32FC1, &dist_coeffs);
+    cv::Mat object_points_mat(4, 3, CV_32FC1);
+    COPY_INTO(object_points_mat, object_points);
+
+    cv::Mat image_points_mat(4, 2, CV_32FC1);
+    COPY_INTO(image_points_mat, image_points);
+
+    cv::Mat camera_matrix_mat(3, 3, CV_32FC1);
+    COPY_INTO(camera_matrix_mat, camera_matrix);
+
+    cv::Mat dist_coeffs_mat(5, 1, CV_32FC1);
+    COPY_INTO(dist_coeffs_mat, dist_coeffs);
 
     cv::Mat rvec_mat(3, 1, CV_32FC1);
     cv::Mat tvec_mat(3, 1, CV_32FC1);

--- a/sb_vision/native/cv3d.cpp
+++ b/sb_vision/native/cv3d.cpp
@@ -63,11 +63,6 @@ int solve_pnp(
     double rvec[],
     double tvec[]
 ) {
-    // printf("object_points: "); print_array(4, 3, object_points);
-    // printf("image_points: "); print_array(4, 2, image_points);
-    // printf("camera_matrix: "); print_array(3, 3, camera_matrix);
-    // printf("dist_coeffs: "); print_array(5, 1, dist_coeffs);
-
     // Copy our input data into OpenCV's Mat wrapper
     cv::Mat object_points_mat(4, 3, CV_64FC1);
     COPY_INTO(object_points_mat, object_points);
@@ -81,11 +76,6 @@ int solve_pnp(
     cv::Mat dist_coeffs_mat(5, 1, CV_64FC1);
     COPY_INTO(dist_coeffs_mat, dist_coeffs);
 
-    // printf("object_points_mat: "); print_mat(object_points_mat);
-    // printf("image_points_mat: "); print_mat(image_points_mat);
-    // printf("camera_matrix_mat: "); print_mat(camera_matrix_mat);
-    // printf("dist_coeffs_mat: "); print_mat(dist_coeffs_mat);
-
     // These are our output data
     cv::Mat rvec_mat, tvec_mat;
 
@@ -98,15 +88,9 @@ int solve_pnp(
         tvec_mat
     );
 
-    // printf("rvec_mat: "); print_mat(rvec_mat);
-    // printf("tvec_mat: "); print_mat(tvec_mat);
-
     // Copy the output data out of OpenCV's wrappers
     memcpy(rvec, rvec_mat.ptr(), 3 * sizeof(double));
     memcpy(tvec, tvec_mat.ptr(), 3 * sizeof(double));
-
-    // printf("rvec: "); print_array(3, 1, rvec);
-    // printf("tvec: "); print_array(3, 1, tvec);
 
     // OpenCV returns the 'y' coordinate positive downwards, yet we want
     // positive meaning upwards

--- a/sb_vision/native/cv3d.cpp
+++ b/sb_vision/native/cv3d.cpp
@@ -1,0 +1,29 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdbool.h>
+#include <string>
+
+extern "C" {
+    int solve_pnp(
+        const void* object_points,
+        const void* image_points,
+        const void* camera_matrix,
+        const void* dist_coeffs,
+        void* rvec,
+        void* tvec
+    );
+}
+
+#include "opencv2/opencv.hpp"
+
+int solve_pnp(
+    const void* object_points,
+    const void* image_points,
+    const void* camera_matrix,
+    const void* dist_coeffs,
+    void* rvec,
+    void* tvec
+) {
+    return 1;
+}

--- a/sb_vision/native/cv3d.cpp
+++ b/sb_vision/native/cv3d.cpp
@@ -3,27 +3,52 @@
 #include <string.h>
 #include <stdbool.h>
 #include <string>
+#include <vector>
 
 extern "C" {
     int solve_pnp(
-        const void* object_points,
-        const void* image_points,
-        const void* camera_matrix,
-        const void* dist_coeffs,
-        void* rvec,
-        void* tvec
+        const float object_points[],
+        const float image_points[],
+        const float camera_matrix[],
+        const float dist_coeffs[],
+        float rvec[],
+        float tvec[]
     );
 }
 
 #include "opencv2/opencv.hpp"
 
 int solve_pnp(
-    const void* object_points,
-    const void* image_points,
-    const void* camera_matrix,
-    const void* dist_coeffs,
-    void* rvec,
-    void* tvec
+    const float object_points[],
+    const float image_points[],
+    const float camera_matrix[],
+    const float dist_coeffs[],
+    float rvec[],
+    float tvec[]
 ) {
-    return 1;
+    cv::Mat object_points_mat(4, 3, CV_32FC1, &object_points);
+    cv::Mat image_points_mat(4, 2, CV_32FC1, &image_points);
+    cv::Mat camera_matrix_mat(3, 3, CV_32FC1, &camera_matrix);
+    cv::Mat dist_coeffs_mat(5, 1, CV_32FC1, &dist_coeffs);
+
+    cv::Mat rvec_mat(3, 1, CV_32FC1);
+    cv::Mat tvec_mat(3, 1, CV_32FC1);
+
+    bool ret = cv::solvePnP(
+        object_points_mat,
+        image_points_mat,
+        camera_matrix_mat,
+        dist_coeffs_mat,
+        rvec_mat,
+        tvec_mat
+    );
+
+    memcpy(rvec, rvec_mat.ptr(), 3 * sizeof(float));
+    memcpy(tvec, tvec_mat.ptr(), 3 * sizeof(float));
+
+    // OpenCV returns the 'y' coordinate positive downwards, yet we want
+    // positive meaning upwards
+    tvec[1] = -tvec[1];
+
+    return (int) ret;
 }

--- a/sb_vision/native/cv3d.cpp
+++ b/sb_vision/native/cv3d.cpp
@@ -85,20 +85,30 @@ int solve_pnp(
     // printf("camera_matrix_mat: "); print_mat(camera_matrix_mat);
     // printf("dist_coeffs_mat: "); print_mat(dist_coeffs_mat);
 
-    cv::Mat rvec_mat(3, 1, CV_32FC1);
-    cv::Mat tvec_mat(3, 1, CV_32FC1);
+    cv::Mat rvec_mat_double, tvec_mat_double;
 
     bool ret = cv::solvePnP(
         object_points_mat,
         image_points_mat,
         camera_matrix_mat,
         dist_coeffs_mat,
-        rvec_mat,
-        tvec_mat
+        rvec_mat_double,
+        tvec_mat_double
     );
+
+    // Convert back to floats (solvePnP gives us doubles)
+    cv::Mat rvec_mat, tvec_mat;
+    rvec_mat_double.convertTo(rvec_mat, CV_32FC1);
+    tvec_mat_double.convertTo(tvec_mat, CV_32FC1);
+
+    // printf("rvec_mat: "); print_mat(rvec_mat_double);
+    // printf("tvec_mat: "); print_mat(tvec_mat_double);
 
     memcpy(rvec, rvec_mat.ptr(), 3 * sizeof(float));
     memcpy(tvec, tvec_mat.ptr(), 3 * sizeof(float));
+
+    // printf("rvec: "); print_array(3, 1, rvec);
+    // printf("tvec: "); print_array(3, 1, tvec);
 
     // OpenCV returns the 'y' coordinate positive downwards, yet we want
     // positive meaning upwards

--- a/sb_vision/native/cv3d.cpp
+++ b/sb_vision/native/cv3d.cpp
@@ -64,16 +64,16 @@ int solve_pnp(
     double tvec[]
 ) {
     // Copy our input data into OpenCV's Mat wrapper
-    cv::Mat object_points_mat(4, 3, CV_64FC1);
+    cv::Mat object_points_mat(4, 3, cv::DataType<double>::type);
     COPY_INTO(object_points_mat, object_points);
 
-    cv::Mat image_points_mat(4, 2, CV_64FC1);
+    cv::Mat image_points_mat(4, 2, cv::DataType<double>::type);
     COPY_INTO(image_points_mat, image_points);
 
-    cv::Mat camera_matrix_mat(3, 3, CV_64FC1);
+    cv::Mat camera_matrix_mat(3, 3, cv::DataType<double>::type);
     COPY_INTO(camera_matrix_mat, camera_matrix);
 
-    cv::Mat dist_coeffs_mat(5, 1, CV_64FC1);
+    cv::Mat dist_coeffs_mat(5, 1, cv::DataType<double>::type);
     COPY_INTO(dist_coeffs_mat, dist_coeffs);
 
     // These are our output data

--- a/sb_vision/native/cv3d.cpp
+++ b/sb_vision/native/cv3d.cpp
@@ -7,10 +7,10 @@
 
 extern "C" {
     int solve_pnp(
-        const float object_points[],
-        const float image_points[],
-        const float camera_matrix[],
-        const float dist_coeffs[],
+        const double object_points[],
+        const double image_points[],
+        const double camera_matrix[],
+        const double dist_coeffs[],
         double rvec[],
         double tvec[]
     );
@@ -18,7 +18,7 @@ extern "C" {
 
 #include "opencv2/opencv.hpp"
 
-void print_array(const int rows, const int cols, const float values[]) {
+void print_array(const int rows, const int cols, const double values[]) {
     printf("[\n");
     for (int i=0; i<rows; i++) {
         printf("  [");
@@ -40,7 +40,7 @@ void print_mat(cv::Mat& mat) {
     for (int i=0; i<mat.rows; i++) {
         printf("  [");
         for (int j=0; j<mat.cols; j++) {
-            float * val = (float *)mat.ptr(i, j);
+            double * val = (double *)mat.ptr(i, j);
             printf("%f", *val);
             if (j+1 < mat.cols) {
                 printf(", ");
@@ -52,14 +52,14 @@ void print_mat(cv::Mat& mat) {
 }
 
 #define COPY_INTO(mat, data) \
-    memcpy(mat.ptr(), data, mat.rows * mat.cols * sizeof(float));
+    memcpy(mat.ptr(), data, mat.rows * mat.cols * sizeof(double));
 
 
 int solve_pnp(
-    const float object_points[],
-    const float image_points[],
-    const float camera_matrix[],
-    const float dist_coeffs[],
+    const double object_points[],
+    const double image_points[],
+    const double camera_matrix[],
+    const double dist_coeffs[],
     double rvec[],
     double tvec[]
 ) {
@@ -68,16 +68,16 @@ int solve_pnp(
     // printf("camera_matrix: "); print_array(3, 3, camera_matrix);
     // printf("dist_coeffs: "); print_array(5, 1, dist_coeffs);
 
-    cv::Mat object_points_mat(4, 3, CV_32FC1);
+    cv::Mat object_points_mat(4, 3, CV_64FC1);
     COPY_INTO(object_points_mat, object_points);
 
-    cv::Mat image_points_mat(4, 2, CV_32FC1);
+    cv::Mat image_points_mat(4, 2, CV_64FC1);
     COPY_INTO(image_points_mat, image_points);
 
-    cv::Mat camera_matrix_mat(3, 3, CV_32FC1);
+    cv::Mat camera_matrix_mat(3, 3, CV_64FC1);
     COPY_INTO(camera_matrix_mat, camera_matrix);
 
-    cv::Mat dist_coeffs_mat(5, 1, CV_32FC1);
+    cv::Mat dist_coeffs_mat(5, 1, CV_64FC1);
     COPY_INTO(dist_coeffs_mat, dist_coeffs);
 
     // printf("object_points_mat: "); print_mat(object_points_mat);

--- a/sb_vision/native/cv3d.cpp
+++ b/sb_vision/native/cv3d.cpp
@@ -18,6 +18,38 @@ extern "C" {
 
 #include "opencv2/opencv.hpp"
 
+void print_array(const int rows, const int cols, const float values[]) {
+    printf("[\n");
+    for (int i=0; i<rows; i++) {
+        printf("  [");
+        for (int j=0; j<cols; j++) {
+            int idx = (i * cols) + j;
+            printf("%f", values[idx]);
+            if (j+1 < cols) {
+                printf(", ");
+            }
+        }
+        printf("],\n");
+    }
+    printf("]\n");
+}
+
+void print_mat(cv::Mat& mat) {
+    printf("[\n");
+    for (int i=0; i<mat.rows; i++) {
+        printf("  [");
+        for (int j=0; j<mat.cols; j++) {
+            float * val = (float *)mat.ptr(i, j);
+            printf("%f", *val);
+            if (j+1 < mat.cols) {
+                printf(", ");
+            }
+        }
+        printf("],\n");
+    }
+    printf("]\n");
+}
+
 #define COPY_INTO(mat, data) \
     memcpy(mat.ptr(), data, mat.rows * mat.cols * sizeof(float));
 
@@ -30,6 +62,11 @@ int solve_pnp(
     float rvec[],
     float tvec[]
 ) {
+    // printf("object_points: "); print_array(4, 3, object_points);
+    // printf("image_points: "); print_array(4, 2, image_points);
+    // printf("camera_matrix: "); print_array(3, 3, camera_matrix);
+    // printf("dist_coeffs: "); print_array(5, 1, dist_coeffs);
+
     cv::Mat object_points_mat(4, 3, CV_32FC1);
     COPY_INTO(object_points_mat, object_points);
 
@@ -41,6 +78,11 @@ int solve_pnp(
 
     cv::Mat dist_coeffs_mat(5, 1, CV_32FC1);
     COPY_INTO(dist_coeffs_mat, dist_coeffs);
+
+    // printf("object_points_mat: "); print_mat(object_points_mat);
+    // printf("image_points_mat: "); print_mat(image_points_mat);
+    // printf("camera_matrix_mat: "); print_mat(camera_matrix_mat);
+    // printf("dist_coeffs_mat: "); print_mat(dist_coeffs_mat);
 
     cv::Mat rvec_mat(3, 1, CV_32FC1);
     cv::Mat tvec_mat(3, 1, CV_32FC1);

--- a/sb_vision/native/cv3d_build.py
+++ b/sb_vision/native/cv3d_build.py
@@ -19,8 +19,8 @@ CV3D_DECLS = """
         const float image_points[],
         const float camera_matrix[],
         const float dist_coeffs[],
-        float rvec[],
-        float tvec[]
+        double rvec[],
+        double tvec[]
     );
 """
 

--- a/sb_vision/native/cv3d_build.py
+++ b/sb_vision/native/cv3d_build.py
@@ -1,0 +1,42 @@
+"""
+CFFI build script for the cv3d native module.
+
+This little bit of code is responsible for fondling OpenCV so that we can
+extract 3D position information from the 2D information we get from AprilTags.
+"""
+
+from pathlib import Path
+
+import cffi
+
+base = Path(__file__).parent
+
+ffibuilder = cffi.FFI()
+
+CV3D_DECLS = """
+    int solve_pnp(
+        const void* object_points,
+        const void* image_points,
+        const void* camera_matrix,
+        const void* dist_coeffs,
+        void* rvec,
+        void* tvec
+    );
+"""
+
+ffibuilder.set_source(
+    "sb_vision.native._cv3d",
+    CV3D_DECLS,
+    sources=[
+        str(base / 'cv3d.cpp'),
+    ],
+    libraries=[
+        'opencv_core',
+        'opencv_calib3d',
+    ],
+)
+
+ffibuilder.cdef(CV3D_DECLS)
+
+if __name__ == '__main__':
+    ffibuilder.compile(verbose=True)

--- a/sb_vision/native/cv3d_build.py
+++ b/sb_vision/native/cv3d_build.py
@@ -15,10 +15,10 @@ ffibuilder = cffi.FFI()
 
 CV3D_DECLS = """
     int solve_pnp(
-        const float object_points[],
-        const float image_points[],
-        const float camera_matrix[],
-        const float dist_coeffs[],
+        const double object_points[],
+        const double image_points[],
+        const double camera_matrix[],
+        const double dist_coeffs[],
         double rvec[],
         double tvec[]
     );

--- a/sb_vision/native/cv3d_build.py
+++ b/sb_vision/native/cv3d_build.py
@@ -15,12 +15,12 @@ ffibuilder = cffi.FFI()
 
 CV3D_DECLS = """
     int solve_pnp(
-        const void* object_points,
-        const void* image_points,
-        const void* camera_matrix,
-        const void* dist_coeffs,
-        void* rvec,
-        void* tvec
+        const float object_points[],
+        const float image_points[],
+        const float camera_matrix[],
+        const float dist_coeffs[],
+        float rvec[],
+        float tvec[]
     );
 """
 

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     ] + pytest_runner,
     cffi_modules=[
         'sb_vision/native/cvcapture_build.py:ffibuilder',
+        'sb_vision/native/cv3d_build.py:ffibuilder',
         'sb_vision/native/apriltag/apriltag_build.py:ffi',
     ],
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
     ],
     install_requires=[
         'lxml',
-        'opencv-python',
         'Pillow',
         'numpy',
         'scipy',


### PR DESCRIPTION
This introduces a new cffi module which wraps the [`solvePnP`](https://docs.opencv.org/2.4/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html#solvepnp) function we're now using for 3D transforms.