### PR TITLE
reorder changelog to be reverse-chronological

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,13 +1,13 @@
-sb-vision (0) unstable; urgency=low
-
-  * (No changelog)
-
- -- Alistair Lynn <arplynn@gmail.com>  Fri, 28 Jul 2017 18:33:12 +0000
-
-
 sb-vision (2018.2.0) unstable; urgency=low
 
   * (No changelog)
 
  -- Andrew Barrett-Sprot <abarrettsprot@gmail.com>  Sun, 7 March 2017 22:47:00 +0000
+
+
+sb-vision (0) unstable; urgency=low
+
+  * (No changelog)
+
+ -- Alistair Lynn <arplynn@gmail.com>  Fri, 28 Jul 2017 18:33:12 +0000
 


### PR DESCRIPTION
Oops looks like the last change (which was merged) didn't update the version of the .deb file because they need to be reverse-chronological